### PR TITLE
Fix recursive call by redirecting call to underlying stream.

### DIFF
--- a/Confuzzle.Core/CipherStream.cs
+++ b/Confuzzle.Core/CipherStream.cs
@@ -331,8 +331,7 @@ namespace Confuzzle.Core
         /// </remarks>
         public override void SetLength(long value)
         {
-            // TODO ***Jamie - infinite recursive call.
-            SetLength(this.startPosition + value);
+            this.stream.SetLength(this.startPosition + value);
         }
 
         /// <summary>


### PR DESCRIPTION
The method was _supposed_ to operate on the underlying stream. Doh!
